### PR TITLE
Return the legacy login type (Craft|EE2|BigCommerce) in the ajax resp…

### DIFF
--- a/legacylogin/LegacyLoginPlugin.php
+++ b/legacylogin/LegacyLoginPlugin.php
@@ -19,7 +19,7 @@ class LegacyLoginPlugin extends BasePlugin
 
 	const EE2LegacyUserType = 'EE2';
 	const BigCommerceLegacyUserType = 'BigCommerce';
-
+	const NativeUserType = 'Craft';
 
 	// Plugin methods
 	// =========================================================================

--- a/legacylogin/controllers/LegacyLoginController.php
+++ b/legacylogin/controllers/LegacyLoginController.php
@@ -42,7 +42,7 @@ class LegacyLoginController extends BaseController
 
 		// TODO
 
-		// If the User is already logged in, skip straight to processomg this as a successful login.
+		// If the User is already logged in, skip straight to processing this as a successful login.
 		if (craft()->userSession->isLoggedIn())
 		{
 			$this->_handleSuccessfulLogin(false);
@@ -59,9 +59,9 @@ class LegacyLoginController extends BaseController
 		$password = craft()->request->getPost('password');
 		$rememberMe = (bool) craft()->request->getPost('rememberMe');
 
-		if (craft()->legacyLogin->login($loginName, $password, $rememberMe))
+		if ($loginType = craft()->legacyLogin->login($loginName, $password, $rememberMe))
 		{
-			$this->_handleSuccessfulLogin(true);
+			$this->_handleSuccessfulLogin($loginType, true);
 		}
 		else
 		{
@@ -102,11 +102,12 @@ class LegacyLoginController extends BaseController
 	 * Redirects the user after a successful login attempt, or if they visited the Login page while they were already
 	 * logged in.
 	 *
+	 * @param string $loginType What type of login was achieved, legacy or Craft native.
 	 * @param bool $setNotice Whether a flash notice should be set, if this isn't an Ajax request.
 	 *
 	 * @return null
 	 */
-	private function _handleSuccessfulLogin($setNotice = true)
+	private function _handleSuccessfulLogin($loginType, $setNotice = true)
 	{
 
 		// TODO
@@ -141,6 +142,7 @@ class LegacyLoginController extends BaseController
 		{
 			$this->returnJson(array(
 				'success' => true,
+				'legacyLoginType' => $loginType,
 				'returnUrl' => $returnUrl
 			));
 		}
@@ -148,8 +150,10 @@ class LegacyLoginController extends BaseController
 		{
 			if ($setNotice)
 			{
-				craft()->userSession->setNotice(Craft::t('Logged in.'));
+				craft()->userSession->setNotice(Craft::t('Logged in.' ));				
 			}
+			//Store the login method so templates can act on the login type	
+			craft()->httpSession->add("legacyLoginType", $loginType);
 			$this->redirectToPostedUrl($currentUser, $returnUrl);
 		}
 

--- a/legacylogin/helpers/LegacyLogin_BigCommerceHelper.php
+++ b/legacylogin/helpers/LegacyLogin_BigCommerceHelper.php
@@ -201,6 +201,9 @@ class LegacyLogin_BigCommerceHelper extends LegacyLogin_AuthenticationHelper
 				LegacyLoginPlugin::log("Couldn't save the user {$craftUser->username}.", LogLevel::Error);
 
 			}
+			else{
+				craft()->userGroups->assignUserToDefaultGroup($craftUser);
+			}
 
 		}
 		else {
@@ -229,7 +232,6 @@ class LegacyLogin_BigCommerceHelper extends LegacyLogin_AuthenticationHelper
 			if (!$success)
 			{
 				LegacyLoginPlugin::log("There was an error processing new password profile for {$craftUser->username}.", LogLevel::Error);
-
 			}
 
 		}

--- a/legacylogin/helpers/LegacyLogin_Ee2Helper.php
+++ b/legacylogin/helpers/LegacyLogin_Ee2Helper.php
@@ -264,7 +264,9 @@ class LegacyLogin_Ee2Helper extends LegacyLogin_AuthenticationHelper
 				LegacyLoginPlugin::log("Couldn't save the user {$craftUser->username}.", LogLevel::Error);
 
 			}
-
+			else{
+				craft()->userGroups->assignUserToDefaultGroup($craftUser);
+			}
 		}
 		else {
 			$success = true;

--- a/legacylogin/services/LegacyLoginService.php
+++ b/legacylogin/services/LegacyLoginService.php
@@ -56,7 +56,7 @@ class LegacyLoginService extends \CWebUser
 		// First, try logging in a native User.
 
 		$nativeSuccess = craft()->userSession->login($username, $password, $rememberMe);
-		if ($nativeSuccess === true) return true;
+		if ($nativeSuccess === true) return LegacyLoginPlugin::NativeUserType;
 
 		// Okay, we'll try to match and validate a legacy user...
 		// First, validate the provided username/password.
@@ -87,11 +87,11 @@ class LegacyLoginService extends \CWebUser
 
 				case LegacyLoginPlugin::BigCommerceLegacyUserType:
 					if (LegacyLogin_BigCommerceHelper::login($username, $password, $rememberMe))
-						return true;
+						return LegacyLoginPlugin::BigCommerceLegacyUserType;
 
 				case LegacyLoginPlugin::EE2LegacyUserType:
 					if (LegacyLogin_Ee2Helper::login($username, $password, $rememberMe))
-						return true;
+						return LegacyLoginPlugin::EE2LegacyUserType;
 
 			}
 		}

--- a/legacylogin/variables/LegacyLoginVariable.php
+++ b/legacylogin/variables/LegacyLoginVariable.php
@@ -1,0 +1,26 @@
+<?php
+namespace Craft;
+
+/**
+ * LegacyLoginVariable returns the loging type that is stored in the session
+
+ * {@link WebApp::userSession `craft()->legacyLogin`}.
+ *
+ * @author    Top Shelf Craft <michael@michaelrog.com>
+ * @copyright Copyright (c) 2016, Michael Rog
+ * @license   http://topshelfcraft.com/license
+ * @see       http://topshelfcraft.com
+ * @package   craft.plugins.legacylogin
+ * @since     1.0
+ */
+class LegacyLoginVariable
+{
+    /**
+     *
+     * @return Craft|BigCommerce|EE2|null
+     */
+    public function loginType(){
+        return craft()->httpSession->get("legacyLoginType");
+    }
+
+}


### PR DESCRIPTION
…onse and http session data.

Call assignUserToDefaultGroup when successfully creating the user.

I couldn't set a variable with setRouteVariables followed by redirectToPostedUrl, so I opted for storing it in session data (I also tried flash data - I couldn't set data with a custome key, and using 'notice' to returns something like 'Logged In (Craft).' seemed messy and would also not survive e.g. another re-direct.

I figure there are use cases where they might want to hang on to how the user logged in for e.g. onboarding purposes like 'On our old site you did this, now do ....this instead' 

Also, I have added calls to assign the user to the default group as part of the user creation which I believe is standard practise for plugins creating users.
