### PR TITLE
Fix issue where allowAnonymous not allowing non-CP users to log in

### DIFF
--- a/src/controllers/LoginController.php
+++ b/src/controllers/LoginController.php
@@ -30,7 +30,7 @@ class LoginController extends Controller
 	 * @inheritdoc
 	 */
 	protected $allowAnonymous = [
-		'actionLogin'
+		'login'
 	];
 
 	/**


### PR DESCRIPTION
I am not 100% sure if this is something that changed in Craft since, but the allowAnonymous property was not being set correctly. The beforeAction in Controller was checking if the current user was logged in and had CP access, preventing the controller action from running.