### PR TITLE
fix: adding type declaration to fix Craft complaint

### DIFF
--- a/src/controllers/web/LoginController.php
+++ b/src/controllers/web/LoginController.php
@@ -25,7 +25,7 @@ class LoginController extends Controller
 	/**
 	 * @inheritdoc
 	 */
-	protected $allowAnonymous = [
+	protected array|bool|int $allowAnonymous = [
 		'login' => self::ALLOW_ANONYMOUS_LIVE | self::ALLOW_ANONYMOUS_OFFLINE,
 	];
 


### PR DESCRIPTION
Newer versions of Craft 4 throw a fatal error without this type declared. 